### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "async-jsonl"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/async_jsonl/CHANGELOG.md
+++ b/crates/async_jsonl/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/gpmcp/async-jsonl/compare/async-jsonl-v0.4.0...async-jsonl-v0.4.1) - 2025-06-05
+
+### Fixed
+
+- release-plz.toml and readme
+
 ## [0.4.0](https://github.com/gpmcp/async-jsonl/compare/v0.3.1...v0.4.0) - 2025-06-04
 
 ### Added

--- a/crates/async_jsonl/Cargo.toml
+++ b/crates/async_jsonl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-jsonl"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "An efficient async Rust library for reading and processing JSON Lines (JSONL) files using Tokio streams."

--- a/crates/async_jsonl_ci/CHANGELOG.md
+++ b/crates/async_jsonl_ci/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/gpmcp/async-jsonl/releases/tag/async_jsonl_ci-v0.1.0) - 2025-06-05
+
+### Fixed
+
+- release-plz.toml and readme

--- a/crates/async_rev_buf/CHANGELOG.md
+++ b/crates/async_rev_buf/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/gpmcp/async-jsonl/releases/tag/async-rev-buf-v0.1.0) - 2025-06-05
+
+### Fixed
+
+- release-plz.toml and readme


### PR DESCRIPTION



## 🤖 New release

* `async-jsonl`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `async_jsonl_ci`: 0.1.0
* `async-rev-buf`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `async-jsonl`

<blockquote>

## [0.4.1](https://github.com/gpmcp/async-jsonl/compare/async-jsonl-v0.4.0...async-jsonl-v0.4.1) - 2025-06-05

### Fixed

- release-plz.toml and readme
</blockquote>

## `async_jsonl_ci`

<blockquote>

## [0.1.0](https://github.com/gpmcp/async-jsonl/releases/tag/async_jsonl_ci-v0.1.0) - 2025-06-05

### Fixed

- release-plz.toml and readme
</blockquote>

## `async-rev-buf`

<blockquote>

## [0.1.0](https://github.com/gpmcp/async-jsonl/releases/tag/async-rev-buf-v0.1.0) - 2025-06-05

### Fixed

- release-plz.toml and readme
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).